### PR TITLE
S7/timer

### DIFF
--- a/staucktion.sql
+++ b/staucktion.sql
@@ -502,9 +502,9 @@ COPY public.config (id, voter_comission_percentage, photographer_comission_perce
 
 COPY public.cron (id, unit, "interval", last_trigger_time, name, next_trigger_time) FROM stdin;
 1	d	5	\N	timer-starter	\N
-2	h	6	\N	timer-purchase-after-auction	\N
+2	d	5	\N	timer-vote	\N
 3	d	1	\N	timer-auction	\N
-4	d	5	\N	timer-vote	\N
+4	h	6	\N	timer-purchase-after-auction	\N
 \.
 
 

--- a/staucktion.sql
+++ b/staucktion.sql
@@ -182,7 +182,9 @@ CREATE TABLE public.cron (
     id bigint NOT NULL,
     unit character(1) NOT NULL,
     "interval" integer NOT NULL,
-    last_trigger_time timestamp without time zone
+    last_trigger_time timestamp without time zone,
+    name character varying NOT NULL,
+    next_trigger_time timestamp without time zone
 );
 
 
@@ -498,8 +500,11 @@ COPY public.config (id, voter_comission_percentage, photographer_comission_perce
 \.
 
 
-COPY public.cron (id, unit, "interval", last_trigger_time) FROM stdin;
-1	s	10	\N
+COPY public.cron (id, unit, "interval", last_trigger_time, name, next_trigger_time) FROM stdin;
+1	d	5	\N	timer-starter	\N
+2	h	6	\N	timer-purchase-after-auction	\N
+3	d	1	\N	timer-auction	\N
+4	d	5	\N	timer-vote	\N
 \.
 
 
@@ -578,7 +583,7 @@ SELECT pg_catalog.setval('public.category_id_seq', 3, false);
 SELECT pg_catalog.setval('public.config_id_seq', 1, true);
 
 
-SELECT pg_catalog.setval('public.cron_id_seq', 1, true);
+SELECT pg_catalog.setval('public.cron_id_seq', 4, true);
 
 
 SELECT pg_catalog.setval('public.location_id_seq', 5, false);


### PR DESCRIPTION
cron tablosundaki satır sayısı 4 e çıkarıldı böylece aşağıdaki timerlar ayrı ayrı ayarlanabilecek.
timer-starter (auction bütün süreci başlatan timer)
timer-vote (vote süresi)
timer-auction (auction süresi)
timer-purchase-after-auction (satın alım süresi)